### PR TITLE
1.0

### DIFF
--- a/database/migrations/2_create_process_approval_flow_steps_table.php
+++ b/database/migrations/2_create_process_approval_flow_steps_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('process_approval_flow_steps', static function (Blueprint $table) {
             $table->id();
-            $table->foreignId('process_approval_flow_id')->references('id')->on('process_approval_flows');
+            $table->foreignId('process_approval_flow_id')->constrained('process_approval_flows')->cascadeOnDelete();
             $table->foreignId('role_id')->index();
             $table->json('permissions')->nullable();
             $table->integer('order')->nullable()->index();

--- a/database/migrations/3_create_process_approvals_table.php
+++ b/database/migrations/3_create_process_approvals_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('process_approvals', static function (Blueprint $table) {
             $table->id();
             $table->morphs('approvable');
-            $table->foreignId('process_approval_flow_step_id')->nullable()->references('id')->on('process_approval_flow_steps')->cascadeOnDelete();
+            $table->foreignId('process_approval_flow_step_id')->nullable()->constrained('process_approval_flow_steps')->cascadeOnDelete();
             $table->string('approval_action', 12)->default('Approved');
             $table->text('approver_name')->nullable();
             $table->text('comment')->nullable();

--- a/database/migrations/5_add_tenant_ids_to_approval_tables.php
+++ b/database/migrations/5_add_tenant_ids_to_approval_tables.php
@@ -27,14 +27,20 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::table('process_approval_flow_steps', static function (Blueprint $table) {
-            $table->dropColumn('tenant_id');
-        });
-        Schema::table('process_approvals', static function (Blueprint $table) {
-            $table->dropColumn('tenant_id');
-        });
-        Schema::table('process_approval_statuses', static function (Blueprint $table) {
-            $table->dropColumn('tenant_id');
-        });
+        if(Schema::hasColumn('process_approval_flow_steps', 'tenant_id')) {
+            Schema::table('process_approval_flow_steps', static function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
+        if(Schema::hasColumn('process_approvals', 'tenant_id')) {
+            Schema::table('process_approvals', static function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
+        if(Schema::hasColumn('process_approval_statuses', 'tenant_id')) {
+            Schema::table('process_approval_statuses', static function (Blueprint $table) {
+                $table->dropColumn('tenant_id');
+            });
+        }
     }
 };

--- a/src/Models/ProcessApproval.php
+++ b/src/Models/ProcessApproval.php
@@ -4,6 +4,7 @@ namespace RingleSoft\LaravelProcessApproval\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use RingleSoft\LaravelProcessApproval\Traits\MultiTenant;
 
 class ProcessApproval extends Model
@@ -19,6 +20,11 @@ class ProcessApproval extends Model
     public function processApprovalFlowStep(): BelongsTo
     {
         return $this->belongsTo(ProcessApprovalFlowStep::class);
+    }
+
+    public function approvable(): MorphTo
+    {
+        return $this->morphTo('approvable');
     }
 
     public function getSignature()

--- a/src/Traits/Approvable.php
+++ b/src/Traits/Approvable.php
@@ -376,10 +376,11 @@ trait Approvable
             DB::commit();
             if ($approval) {
                 ProcessApprovedEvent::dispatch($approval);
+                if ($this->isApprovalCompleted()) {
+                    ProcessApprovalCompletedEvent::dispatch($this);
+                }
             }
-            if ($this->isApprovalCompleted()) {
-                ProcessApprovalCompletedEvent::dispatch($approval);
-            }
+
             return $approval;
         } catch (Exception $e) {
             Log::error('Process approval failure: ', [$e]);

--- a/src/Traits/Approvable.php
+++ b/src/Traits/Approvable.php
@@ -453,7 +453,7 @@ trait Approvable
                 'approvable_type' => self::getApprovableType(),
                 'approvable_id' => $this->id,
                 'process_approval_flow_step_id' => $nextStep?->id,
-                'approval_action' => ApprovalActionEnum::DISCARDED->value,
+                'approval_action' => ApprovalActionEnum::DISCARDED,
                 'comment' => $comment,
                 'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'
@@ -497,7 +497,7 @@ trait Approvable
                 'approvable_type' => self::getApprovableType(),
                 'approvable_id' => $this->id,
                 'process_approval_flow_step_id' => $nextStep?->id,
-                'approval_action' => ApprovalActionEnum::RETURNED->value,
+                'approval_action' => ApprovalActionEnum::RETURNED,
                 'comment' => $comment,
                 'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'

--- a/src/Traits/Approvable.php
+++ b/src/Traits/Approvable.php
@@ -301,6 +301,7 @@ trait Approvable
         if ($this->approvalStatus->creator_id && $this->approvalStatus->creator_id !== Auth::id()) {
             throw new RuntimeException('Only the creator can submit the record');
         }
+        $user = $user ?? Auth::user();
         try {
             DB::beginTransaction();
             $approval = ProcessApproval::query()->create([
@@ -309,7 +310,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $this->approvalFlowSteps()?->first()?->id ?? null, // Backward compatibility
                 'approval_action' => ApprovalActionEnum::SUBMITTED->value,
                 'comment' => '',
-                'user_id' => $user?->id ?? Auth::id() ?? null,
+                'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             $this->approvalStatus()->update(['status' => ApprovalStatusEnum::SUBMITTED]);
@@ -352,6 +353,7 @@ trait Approvable
         if($this->approvalsPaused) {
             throw ApprovalsPausedException::create($this);
         }
+        $user = $user ?? Auth::user();
         try {
             DB::beginTransaction();
             $approval = ProcessApproval::query()->updateOrCreate([
@@ -360,7 +362,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep->id,
                 'approval_action' => ApprovalActionEnum::APPROVED,
                 'comment' => $comment,
-                'user_id' => $user?->id ?? Auth::id() ?? null,
+                'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             if ($approval) {
@@ -402,6 +404,7 @@ trait Approvable
         if($this->approvalsPaused) {
             throw ApprovalsPausedException::create($this);
         }
+        $user = $user ?? Auth::user();
         try {
             DB::beginTransaction();
             $nextStep = $this->nextApprovalStep();
@@ -411,7 +414,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep?->id,
                 'approval_action' => ApprovalActionEnum::REJECTED,
                 'comment' => $comment,
-                'user_id' => $user?->id  ?? Auth::id() ?? null,
+                'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             DB::commit();
@@ -442,6 +445,7 @@ trait Approvable
         if($this->approvalsPaused) {
             throw ApprovalsPausedException::create($this);
         }
+        $user = $user ?? Auth::user();
         $nextStep = $this->nextApprovalStep();
         DB::beginTransaction();
         try {
@@ -451,7 +455,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep?->id,
                 'approval_action' => ApprovalActionEnum::DISCARDED->value,
                 'comment' => $comment,
-                'user_id' => $user?->id ?? Auth::id() ?? null,
+                'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             $this->updateStatus($nextStep?->id, $approval);
@@ -484,6 +488,7 @@ trait Approvable
         if($this->approvalsPaused) {
             throw ApprovalsPausedException::create($this);
         }
+        $user = $user ?? Auth::user();
         $previousStep = $this->previousApprovalStep();
         $nextStep = $this->nextApprovalStep();
         try {
@@ -494,7 +499,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep?->id,
                 'approval_action' => ApprovalActionEnum::RETURNED->value,
                 'comment' => $comment,
-                'user_id' => $user?->id ?? Auth::id() ?? null,
+                'user_id' => $user?->id,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             if ($previousStep) {

--- a/src/Traits/Approvable.php
+++ b/src/Traits/Approvable.php
@@ -309,7 +309,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $this->approvalFlowSteps()?->first()?->id ?? null, // Backward compatibility
                 'approval_action' => ApprovalActionEnum::SUBMITTED->value,
                 'comment' => '',
-                'user_id' => $user?->id,
+                'user_id' => $user?->id ?? Auth::id() ?? null,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             $this->approvalStatus()->update(['status' => ApprovalStatusEnum::SUBMITTED]);
@@ -360,7 +360,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep->id,
                 'approval_action' => ApprovalActionEnum::APPROVED,
                 'comment' => $comment,
-                'user_id' => $user?->id,
+                'user_id' => $user?->id ?? Auth::id() ?? null,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             if ($approval) {
@@ -411,7 +411,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep?->id,
                 'approval_action' => ApprovalActionEnum::REJECTED,
                 'comment' => $comment,
-                'user_id' => $user?->id,
+                'user_id' => $user?->id  ?? Auth::id() ?? null,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             DB::commit();
@@ -451,7 +451,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep?->id,
                 'approval_action' => ApprovalActionEnum::DISCARDED->value,
                 'comment' => $comment,
-                'user_id' => $user?->id,
+                'user_id' => $user?->id ?? Auth::id() ?? null,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             $this->updateStatus($nextStep?->id, $approval);
@@ -494,7 +494,7 @@ trait Approvable
                 'process_approval_flow_step_id' => $nextStep?->id,
                 'approval_action' => ApprovalActionEnum::RETURNED->value,
                 'comment' => $comment,
-                'user_id' => $user?->id,
+                'user_id' => $user?->id ?? Auth::id() ?? null,
                 'approver_name' => $user?->name ?? 'Unknown'
             ]);
             if ($previousStep) {

--- a/src/Traits/Approvable.php
+++ b/src/Traits/Approvable.php
@@ -376,7 +376,7 @@ trait Approvable
             DB::commit();
             if ($approval) {
                 ProcessApprovedEvent::dispatch($approval);
-                if ($this->isApprovalCompleted()) {
+                if ($this->refresh()->isApprovalCompleted()) {
                     ProcessApprovalCompletedEvent::dispatch($this);
                 }
             }


### PR DESCRIPTION
### Added
- Support for Multi-Tenancy ([#24](https://github.com/ringlesoft/laravel-process-approval/issues/24))
- Ability to return a record to the previous step ([#18](https://github.com/ringlesoft/laravel-process-approval/issues/18))
- Method for seeding the database with approval flows and steps
- Support for Multilanguage

### Fixed
- Resolved compatibility issue with PostgreSQL by removing backticks from SQL queries

### Changed
- Deprecated `getApprovalSummaryUI()` method in favor of `<x-ringlesoft-approval-status-summary>` component
- `web` middleware is applied to the ApprovalController by default

### Additional
- Added testing branch `tests`