### PR TITLE
Process Approval Pending Status Bugfix

### DIFF
--- a/src/Traits/Approvable.php
+++ b/src/Traits/Approvable.php
@@ -194,9 +194,9 @@ trait Approvable
      * Check if Approval process is completed
      * @return bool
      */
-    public function isApprovalCompleted(): bool
+    public function isApprovalCompleted(array $currentSteps = null): bool
     {
-        $registeredSteps = collect($this->approvalStatus->steps ?? []);
+        $registeredSteps = $currentSteps ? collect($currentSteps) : collect($this->approvalStatus->steps ?? []);
         if ($registeredSteps->count() > 0) {
             foreach ($registeredSteps as $item) {
                 if ($item['process_approval_action'] === null || $item['process_approval_id'] === null || $item['process_approval_action'] === ApprovalStatusEnum::RETURNED->value) {
@@ -645,12 +645,13 @@ trait Approvable
             }
             return $step;
         });
-        $action = $approval->approval_action;
-        if ($action === ApprovalStatusEnum::APPROVED->value && !$this->isApprovalCompleted()) {
+        $action = $approval->approval_action->value;
+        $currentSteps = ApprovalStatusStepData::collectionToArray($current);
+        if ($action === ApprovalStatusEnum::APPROVED->value && !$this->isApprovalCompleted($currentSteps)) {
             $action = ApprovalStatusEnum::PENDING->value;
         }
         return $this->approvalStatus()->update([
-            'steps' => ApprovalStatusStepData::collectionToArray($current),
+            'steps' => $currentSteps,
             'status' => $action
         ]);
     }


### PR DESCRIPTION
Reference Issues/PR
none

Description

This is a fix for an issue whereby the `process_approval_statuses` `status` column does not get updated to pending. 

When an approval process is no longer in the submitted state and the `isApprovalCompleted` method is false the `process_approval_statuses` status should be pending, unfortunately due to a type mismatch between the Enum casted status column and the `ApprovalStatusEnum` the condition is never true. Because of this the `process_approval_statuses` only moves between `Submitted` and `Approved`.

This fixes that issue by ensuring that they are of the same type for proper comparison. 

The fix unfortunately introduces a new issue where the status never gets to `Apporved`, this is because we check the `isApprovalCompleted` method before we update the status. This leads to the final approval status always been set to `Pending` because it assumes that the process is not completed yet. 

To fix this I have introduced a nullable variable for the `isApprovalCompleted` method that can take the current steps and use it to confirm if the process is completed.