### PR TITLE
Update ProcessApprovalCompletedEvent.php __construct() to initialize $event->approvable

### DIFF
--- a/src/Events/ProcessApprovalCompletedEvent.php
+++ b/src/Events/ProcessApprovalCompletedEvent.php
@@ -14,12 +14,10 @@ class ProcessApprovalCompletedEvent
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public Model $approvable;
-
     /**
      * Create a new event instance.
      */
-    public function __construct(ApprovableModel $approvable)
+    public function __construct(public ApprovableModel $approvable)
     {
     }
 


### PR DESCRIPTION
ProcessApprovalCompletedEvent now receives an ApprovableModel and can be accessed via $event->approvable. Fixes #55