### PR TITLE
fix roleId should be accept string or int

### DIFF
--- a/src/ProcessApproval.php
+++ b/src/ProcessApproval.php
@@ -104,7 +104,7 @@ class ProcessApproval implements ProcessApprovalContract
      * @inheritDoc
      * @throws ApprovalFlowDoesNotExistsException
      */
-    public function createStep(int $flowId, int $roleId, string|null $action = 'APPROVE', string|int|null $tenantId = null): ProcessApprovalFlowStep
+    public function createStep(int $flowId, string|int $roleId, string|null $action = 'APPROVE', string|int|null $tenantId = null): ProcessApprovalFlowStep
     {
         $flow = ProcessApprovalFlow::find($flowId);
         if(!$flow){


### PR DESCRIPTION
when spatie permission use ulid/uuid it reject to create a step, by this fix it should be accept string/int when roleId is string or integer